### PR TITLE
adding simulatable neuron class and registering function

### DIFF
--- a/bluepyemodel/access_point/forge_access_point.py
+++ b/bluepyemodel/access_point/forge_access_point.py
@@ -37,6 +37,7 @@ from bluepyemodel.emodel_pipeline.emodel_script import EModelScript
 from bluepyemodel.emodel_pipeline.emodel_settings import EModelPipelineSettings
 from bluepyemodel.emodel_pipeline.emodel_workflow import EModelWorkflow
 from bluepyemodel.emodel_pipeline.memodel import MEModel
+from bluepyemodel.emodel_pipeline.simulatableneuron import SimulatableNeuron
 from bluepyemodel.evaluation.fitness_calculator_configuration import FitnessCalculatorConfiguration
 from bluepyemodel.model.distribution_configuration import DistributionConfiguration
 from bluepyemodel.model.neuron_model_configuration import NeuronModelConfiguration
@@ -57,6 +58,7 @@ CLASS_TO_NEXUS_TYPE = {
     "EModelWorkflow": "EModelWorkflow",
     "EModelScript": "EModelScript",
     "MEModel": "MEModel",
+    "SimulatableNeuron": "SimulatableNeuron",
 }
 
 CLASS_TO_RESOURCE_NAME = {
@@ -69,6 +71,7 @@ CLASS_TO_RESOURCE_NAME = {
     "EModelWorkflow": "EMW",
     "EModelScript": "EMS",
     "MEModel": "MEM",
+    "SimulatableNeuron": "SN"
 }
 
 NEXUS_TYPE_TO_CLASS = {
@@ -81,6 +84,7 @@ NEXUS_TYPE_TO_CLASS = {
     "EModelWorkflow": EModelWorkflow,
     "EModelScript": EModelScript,
     "MEModel": MEModel,
+    "SimulatableNeuron": SimulatableNeuron
 }
 
 NEXUS_ENTRIES = [
@@ -437,7 +441,10 @@ class NexusForgeAccessPoint:
         # when EModelWorkflow resource is complete
         if type_ == "EModelWorkflow":
             type_ = "Entity"
-        schema_id = self.forge._model.schema_id(type_)
+        if type_ == "SimulatableNeuron":
+            schema_id = None
+        else:
+            schema_id = self.forge._model.schema_id(type_)
 
         self.forge.register(resource, schema_id=schema_id)
 

--- a/bluepyemodel/access_point/forge_access_point.py
+++ b/bluepyemodel/access_point/forge_access_point.py
@@ -37,7 +37,7 @@ from bluepyemodel.emodel_pipeline.emodel_script import EModelScript
 from bluepyemodel.emodel_pipeline.emodel_settings import EModelPipelineSettings
 from bluepyemodel.emodel_pipeline.emodel_workflow import EModelWorkflow
 from bluepyemodel.emodel_pipeline.memodel import MEModel
-from bluepyemodel.emodel_pipeline.simulatableneuron import SimulatableNeuron
+from bluepyemodel.emodel_pipeline.simulatable_neuron import SimulatableNeuron
 from bluepyemodel.evaluation.fitness_calculator_configuration import FitnessCalculatorConfiguration
 from bluepyemodel.model.distribution_configuration import DistributionConfiguration
 from bluepyemodel.model.neuron_model_configuration import NeuronModelConfiguration
@@ -71,7 +71,7 @@ CLASS_TO_RESOURCE_NAME = {
     "EModelWorkflow": "EMW",
     "EModelScript": "EMS",
     "MEModel": "MEM",
-    "SimulatableNeuron": "SN"
+    "SimulatableNeuron": "SN",
 }
 
 NEXUS_TYPE_TO_CLASS = {
@@ -84,7 +84,7 @@ NEXUS_TYPE_TO_CLASS = {
     "EModelWorkflow": EModelWorkflow,
     "EModelScript": EModelScript,
     "MEModel": MEModel,
-    "SimulatableNeuron": SimulatableNeuron
+    "SimulatableNeuron": SimulatableNeuron,
 }
 
 NEXUS_ENTRIES = [
@@ -441,9 +441,8 @@ class NexusForgeAccessPoint:
         # when EModelWorkflow resource is complete
         if type_ == "EModelWorkflow":
             type_ = "Entity"
-        if type_ == "SimulatableNeuron":
-            schema_id = None
-        else:
+        schema_id = None
+        if type_ != "SimulatableNeuron":
             schema_id = self.forge._model.schema_id(type_)
 
         self.forge.register(resource, schema_id=schema_id)

--- a/bluepyemodel/access_point/nexus.py
+++ b/bluepyemodel/access_point/nexus.py
@@ -1486,3 +1486,39 @@ class NexusAccessPoint(DataAccessPoint):
             return True
         except AccessPointException:
             return False
+
+    def store_simulatable_neuron(
+        self, simulatable_neuron, is_analysis_suitable=False
+    ):
+        """Store a BPEM object on Nexus
+        
+        Args:
+            simulatable_neuron (SimulatableNeuron)
+            is_analysis_suitable (bool): Should be True only when managing metatada for resources
+                of type EModel, for which all data are complete (has FCC, ETC, EMC, etc.).
+        """
+
+        metadata_dict = self.emodel_metadata_ontology.for_resource(
+            is_analysis_suitable=is_analysis_suitable
+        )
+
+        type_ = "SimulatableNeuron"
+
+        base_payload = simulatable_neuron.as_dict()
+        base_payload["type"] = ["Entity", type_]
+        if "subject" in metadata_dict:
+            base_payload["subject"] = metadata_dict["subject"]
+        if "brainLocation" in metadata_dict:
+            base_payload["brainLocation"] = metadata_dict["brainLocation"]
+        if "annotation" in metadata_dict:
+            base_payload["annotation"] = metadata_dict["annotation"]
+
+        self.forge.register(
+            base_payload,
+            filters_existence=None,
+            legacy_filters_existence=None,
+            replace=False,
+            distributions=None,
+            images=None,
+            type_=type_,
+        )

--- a/bluepyemodel/access_point/nexus.py
+++ b/bluepyemodel/access_point/nexus.py
@@ -1487,11 +1487,9 @@ class NexusAccessPoint(DataAccessPoint):
         except AccessPointException:
             return False
 
-    def store_simulatable_neuron(
-        self, simulatable_neuron, is_analysis_suitable=False
-    ):
+    def store_simulatable_neuron(self, simulatable_neuron, is_analysis_suitable=False):
         """Store a BPEM object on Nexus
-        
+
         Args:
             simulatable_neuron (SimulatableNeuron)
             is_analysis_suitable (bool): Should be True only when managing metatada for resources
@@ -1513,7 +1511,7 @@ class NexusAccessPoint(DataAccessPoint):
         if "annotation" in metadata_dict:
             base_payload["annotation"] = metadata_dict["annotation"]
 
-        self.forge.register(
+        self.access_point.register(
             base_payload,
             filters_existence=None,
             legacy_filters_existence=None,

--- a/bluepyemodel/emodel_pipeline/simulatable_neuron.py
+++ b/bluepyemodel/emodel_pipeline/simulatable_neuron.py
@@ -1,3 +1,5 @@
+"""SimulatableNeuron class"""
+
 """
 Copyright 2025 Open Brain Institute
 
@@ -19,22 +21,24 @@ class SimulatableNeuron:
     """Whole neuron model, including links to morphology, ion channels models and hoc."""
 
     def __init__(
-            self,
-            description,
-            emodel_script_id,
-            mechanism_ids,
-            morphology_id,
-            holding_current=None,
-            threshold_current=None,
-            validated=False,
-        ):
+        self,
+        name,
+        description,
+        emodel_script_id,
+        mechanism_ids,
+        morphology_id,
+        holding_current=None,
+        threshold_current=None,
+        validated=False,
+    ):
         """Init
 
         from_circuit and synaptomes, that might be present in the database,
         are not implemented here.
-        name, eModel, eType, subject, brainRegion are automatically filled in by forge_access_point for now using emodel_metadata
-        
+        subject, brainRegion are coming emodel_metadata
+
         Args:
+            name (str): name
             description (str): description of the model
             emodel_script_id (str): ID of the hoc model in the database
             mechanism_ids (list of str): IDs of the ion channel models in the database
@@ -44,6 +48,7 @@ class SimulatableNeuron:
             validated (bool): whether the model has been validated by user
         """
         # check if brain region and subject are automatically added
+        self.name = name
         self.description = description
         self.emodel_script_id = emodel_script_id
         self.mechanism_ids = mechanism_ids

--- a/bluepyemodel/emodel_pipeline/simulatable_neuron.py
+++ b/bluepyemodel/emodel_pipeline/simulatable_neuron.py
@@ -1,0 +1,57 @@
+"""
+Copyright 2025 Open Brain Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+class SimulatableNeuron:
+    """Whole neuron model, including links to morphology, ion channels models and hoc."""
+
+    def __init__(
+            self,
+            description,
+            emodel_script_id,
+            mechanism_ids,
+            morphology_id,
+            holding_current=None,
+            threshold_current=None,
+            validated=False,
+        ):
+        """Init
+
+        from_circuit and synaptomes, that might be present in the database,
+        are not implemented here.
+        name, eModel, eType, subject, brainRegion are automatically filled in by forge_access_point for now using emodel_metadata
+        
+        Args:
+            description (str): description of the model
+            emodel_script_id (str): ID of the hoc model in the database
+            mechanism_ids (list of str): IDs of the ion channel models in the database
+            morphology_id (str): ID of the morphology in the database
+            holding_current (float): holding current to use in protocols (in nA)
+            threshold_current (float): current at which the cell starts firing (in nA)
+            validated (bool): whether the model has been validated by user
+        """
+        # check if brain region and subject are automatically added
+        self.description = description
+        self.emodel_script_id = emodel_script_id
+        self.mechanism_ids = mechanism_ids
+        self.morphology_id = morphology_id
+        self.holding_current = holding_current
+        self.threshold_current = threshold_current
+        self.validated = validated
+
+    def as_dict(self):
+        """Used for the storage of the object"""
+        return vars(self)


### PR DESCRIPTION
- adding a new class: SimulatableNeuron
- adding a new nexus function to register SimulatableNeuron into the nexus database

Since we are going to move away from nexus, I took some liberties:
- No file attached to simulatableneuron resource. Metadata conform to the schema, we don't need a json file since everything is in the metadata, and we don't duplicate any morph/mech/hoc. Download button on the platform will have to get mech/morph/hoc from ids.
- No eModel or eType or iteration_tag in the metadata, to conform to future new standards in schemas.
- No file and no eModel, etc. means that we won't be able to fetch the resource the way we were doing in BluePyEModel. So I did not create any get_sumlatable_neuron in the NexusAccessPoint. We will have to figure this out when we create the new entitycore access point.
- Since we don't have eModel, etc., we cannot automatically replace the resource when we upload it a second time. We will have to be aware of that.
- I did not implement from_circuit and synaptomes, that have been added in the schema by Christoph. Since this is just to upload our models for now it is ok. We will have to think later if we should add those fields in BPEM also.

This has not been tested yet. We are waiting on being able to use nexus again.